### PR TITLE
If creating a group with the same name as the username fails, reuse t…

### DIFF
--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -411,7 +411,11 @@ else
     if [ "${USER_UID}" = "automatic" ]; then
         useradd -s /bin/bash --gid $USERNAME -m $USERNAME
     else
-        useradd -s /bin/bash --uid $USER_UID --gid $USERNAME -m $USERNAME
+        if getent group $USERNAME > /dev/null 2>&1; then
+            useradd -s /bin/bash --uid $USER_UID --gid $USERNAME -m $USERNAME
+        else
+            useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME
+        fi
     fi
 fi
 


### PR DESCRIPTION
…he existing group.